### PR TITLE
Fix images to use markdown-style embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 # box
 A JavaScript-based package manager for Linux.
 
-[![Made with JavaScript badge](https://forthebadge.com/images/badges/made-with-javascript.svg)]()
-[![Open source badge](https://forthebadge.com/images/badges/open-source.svg)]()
+[![Made with JavaScript badge](https://forthebadge.com/images/badges/made-with-javascript.svg)](#)
+[![Open source badge](https://forthebadge.com/images/badges/open-source.svg)](#)
 
 ## The advantages of box
 - **Very lightweight**, it weighs around 300kb.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![box logo](https://i.imgur.com/yjIG9tA.png")]()
+[![box logo](https://i.imgur.com/yjIG9tA.png")](#)
 
 # box
 A JavaScript-based package manager for Linux.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-<img src="https://i.imgur.com/yjIG9tA.png">
+[![box logo](https://i.imgur.com/yjIG9tA.png")]()
 
-## box
-A JavaScript based package manager for Linux.
+# box
+A JavaScript-based package manager for Linux.
 
-<div style="text-align:center"><img src="https://forthebadge.com/images/badges/made-with-javascript.svg">   <img src=https://forthebadge.com/images/badges/open-source.svg></div>
+[![Made with JavaScript badge](https://forthebadge.com/images/badges/made-with-javascript.svg)]()
+[![Open source badge](https://forthebadge.com/images/badges/open-source.svg)]()
 
 ## The advantages of box
 - **Very lightweight**, it weighs around 300kb.


### PR DESCRIPTION
Some renderers don't support HTML-style image embedding; also I removed the image links so that when you click on the images, they don't do anything